### PR TITLE
feat: Allow for readonly bucket access

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,0 +1,2 @@
+version: 1
+module_version: 0.0.1

--- a/variables.tf
+++ b/variables.tf
@@ -373,6 +373,21 @@ variable "privileged_principal_actions" {
   description = "List of actions to permit `privileged_principal_arns` to perform on bucket and bucket prefixes (see `privileged_principal_arns`)"
 }
 
+variable "readonly_principal_arns" {
+  type    = list(string)
+  default = []
+
+  description = <<-EOT
+    List of arns to grant `readonly_principal_arns` permissions to `readonly_principal_actions` for the bucket.
+    EOT
+}
+
+variable "readonly_principal_actions" {
+  type        = list(string)
+  default     = []
+  description = "List of actions to permit `readonly_principal_arns` to perform on bucket and bucket prefixes (see `readonly_principal_arns`)"
+}
+
 variable "transfer_acceleration_enabled" {
   type        = bool
   default     = false


### PR DESCRIPTION
## what

Allow for readonly bucket access.

## why

* We need to be able to grant both "privileged" access to our service account ARN (which is already accounted for), but also "readonly" access, which will use different ARNs and different actions.
* We need to consolidate where `aws_iam_policy_document` is modified to avoid the current "infinite drift" problem in crow.

