### PR TITLE
fix: Correct invalid resource

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,2 +1,2 @@
 version: 1
-module_version: 0.0.1
+module_version: 0.0.2

--- a/main.tf
+++ b/main.tf
@@ -460,7 +460,7 @@ data "aws_iam_policy_document" "bucket_policy" {
       actions = var.readonly_principal_actions
       resources = distinct(flatten([
         "arn:${local.partition}:s3:::${join("", aws_s3_bucket.default.*.id)}",
-        formatlist("arn:${local.partition}:s3:::${join("", aws_s3_bucket.default.*.id)}/%s*", statement.value),
+        "arn:${local.partition}:s3:::${join("", aws_s3_bucket.default.*.id)}/*",
       ]))
       principals {
         type        = "AWS"


### PR DESCRIPTION
## what

Correct invalid resource.

## why

Previous `Resource` block looked like this: 
```
"Resource": [
    "arn:aws:s3:::bucket-name/arn:aws:iam::account-id:role/apz@all*",
    "arn:aws:s3:::bucket-name"
]
```
