### PR TITLE
Bucket defects

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -73,11 +73,13 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
   bucket = join("", aws_s3_bucket.default.*.id)
 
   rule {
-    bucket_key_enabled = var.bucket_key_enabled
+    # Bucket Keys are only valid for SSE-KMS
+    bucket_key_enabled = var.sse_algorithm == "aws:kms" ? var.bucket_key_enabled : false
 
     apply_server_side_encryption_by_default {
-      sse_algorithm     = var.sse_algorithm
-      kms_master_key_id = var.kms_master_key_arn
+      sse_algorithm = var.sse_algorithm
+      # Only valid for SSE-KMS; empty string is treated as unset.
+      kms_master_key_id = var.sse_algorithm == "aws:kms" && try(length(var.kms_master_key_arn), 0) > 0 ? var.kms_master_key_arn : null
     }
   }
 }

--- a/module-tests/main.tf
+++ b/module-tests/main.tf
@@ -1,27 +1,27 @@
 module "public_bucket" {
-  source  = "../"
+  source = "../"
 
-  acl                     = "public-read" 
+  acl                     = "public-read"
   block_public_acls       = false
   block_public_policy     = false
   ignore_public_acls      = false
   restrict_public_buckets = false
 
-  name = var.public_bucket_name
+  name   = var.public_bucket_name
   tenant = var.tenant
-  stage = var.stage
+  stage  = var.stage
 }
 
 module "private_bucket" {
-  source  = "../"
+  source = "../"
 
-  acl                     = "private" 
+  acl                     = "private"
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
 
-  name = var.private_bucket_name
+  name   = var.private_bucket_name
   tenant = var.tenant
-  stage = var.stage
+  stage  = var.stage
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,12 +9,12 @@ output "bucket_regional_domain_name" {
 }
 
 output "bucket_website_domain" {
-  value       = join("", aws_s3_bucket_website_configuration.default.*.website_domain, aws_s3_bucket_website_configuration.redirect.*.website_domain)
+  value       = join("", concat(aws_s3_bucket_website_configuration.default.*.website_domain, aws_s3_bucket_website_configuration.redirect.*.website_domain))
   description = "The bucket website domain, if website is enabled"
 }
 
 output "bucket_website_endpoint" {
-  value       = join("", aws_s3_bucket_website_configuration.default.*.website_endpoint, aws_s3_bucket_website_configuration.redirect.*.website_endpoint)
+  value       = join("", concat(aws_s3_bucket_website_configuration.default.*.website_endpoint, aws_s3_bucket_website_configuration.redirect.*.website_endpoint))
   description = "The bucket website endpoint, if website is enabled"
 }
 

--- a/replication.tf
+++ b/replication.tf
@@ -59,7 +59,7 @@ data "aws_iam_policy_document" "replication" {
 
     resources = toset(concat(
       try(length(var.s3_replica_bucket_arn), 0) > 0 ? ["${var.s3_replica_bucket_arn}/*"] : [],
-      [for rule in local.s3_replication_rules : "${rule.destination_bucket}/*" if try(length(rule.destination_bucket), 0) > 0],
+      [for rule in(local.s3_replication_rules == null ? [] : local.s3_replication_rules) : "${rule.destination_bucket}/*" if try(length(rule.destination_bucket), 0) > 0],
     ))
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -243,14 +243,6 @@ variable "s3_replication_enabled" {
     condition     = !var.s3_replication_enabled || length(coalesce(var.replication_rules, var.s3_replication_rules, [])) > 0
     error_message = "When s3_replication_enabled is true, you must provide at least one replication rule via s3_replication_rules (or deprecated replication_rules)."
   }
-
-  validation {
-    condition = !var.s3_replication_enabled || (
-      try(length(var.s3_replica_bucket_arn), 0) > 0 ||
-      anytrue([for r in coalesce(var.replication_rules, var.s3_replication_rules, []) : try(length(r.destination_bucket), 0) > 0])
-    )
-    error_message = "When s3_replication_enabled is true, you must set s3_replica_bucket_arn or set destination_bucket in at least one replication rule."
-  }
 }
 
 variable "s3_replica_bucket_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -347,11 +347,6 @@ variable "website_redirect_all_requests_to" {
     condition     = length(var.website_redirect_all_requests_to) < 2
     error_message = "Only 1 website_redirect_all_requests_to is allowed."
   }
-
-  validation {
-    condition     = length(var.website_redirect_all_requests_to) == 0 || length(var.website_configuration) == 0
-    error_message = "website_redirect_all_requests_to is mutually exclusive with website_configuration."
-  }
 }
 
 variable "website_configuration" {

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,11 @@ variable "sse_algorithm" {
   type        = string
   default     = "AES256"
   description = "The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`"
+
+  validation {
+    condition     = contains(["AES256", "aws:kms"], var.sse_algorithm)
+    error_message = "Valid values for sse_algorithm are \"AES256\" and \"aws:kms\"."
+  }
 }
 
 variable "kms_master_key_arn" {
@@ -228,6 +233,24 @@ variable "s3_replication_enabled" {
   type        = bool
   default     = false
   description = "Set this to true and specify `s3_replication_rules` to enable replication. `versioning_enabled` must also be `true`."
+
+  validation {
+    condition     = !var.s3_replication_enabled || var.versioning_enabled
+    error_message = "When s3_replication_enabled is true, versioning_enabled must also be true."
+  }
+
+  validation {
+    condition     = !var.s3_replication_enabled || length(coalesce(var.replication_rules, var.s3_replication_rules, [])) > 0
+    error_message = "When s3_replication_enabled is true, you must provide at least one replication rule via s3_replication_rules (or deprecated replication_rules)."
+  }
+
+  validation {
+    condition = !var.s3_replication_enabled || (
+      try(length(var.s3_replica_bucket_arn), 0) > 0 ||
+      anytrue([for r in coalesce(var.replication_rules, var.s3_replication_rules, []) : try(length(r.destination_bucket), 0) > 0])
+    )
+    error_message = "When s3_replication_enabled is true, you must set s3_replica_bucket_arn or set destination_bucket in at least one replication rule."
+  }
 }
 
 variable "s3_replica_bucket_arn" {
@@ -324,6 +347,11 @@ variable "website_redirect_all_requests_to" {
     condition     = length(var.website_redirect_all_requests_to) < 2
     error_message = "Only 1 website_redirect_all_requests_to is allowed."
   }
+
+  validation {
+    condition     = length(var.website_redirect_all_requests_to) == 0 || length(var.website_configuration) == 0
+    error_message = "website_redirect_all_requests_to is mutually exclusive with website_configuration."
+  }
 }
 
 variable "website_configuration" {
@@ -350,6 +378,11 @@ variable "website_configuration" {
   validation {
     condition     = length(var.website_configuration) < 2
     error_message = "Only 1 website_configuration is allowed."
+  }
+
+  validation {
+    condition     = length(var.website_configuration) == 0 || length(var.website_redirect_all_requests_to) == 0
+    error_message = "website_configuration is mutually exclusive with website_redirect_all_requests_to."
   }
 }
 
@@ -417,4 +450,9 @@ variable "bucket_key_enabled" {
   Set this to true to use Amazon S3 Bucket Keys for SSE-KMS, which may reduce the number of AWS KMS requests.
   For more information, see: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html
   EOT
+
+  validation {
+    condition     = !var.bucket_key_enabled || var.sse_algorithm == "aws:kms"
+    error_message = "bucket_key_enabled can only be true when sse_algorithm is \"aws:kms\"."
+  }
 }


### PR DESCRIPTION
## what

*   Fixed a Terraform syntax error in `outputs.tf` related to website outputs.
*   Addressed a null iteration bug in `replication.tf` for IAM policy rules.
*   Corrected SSE configuration in `main.tf` to conditionally set KMS-specific fields.
*   Added input validations in `variables.tf` for `sse_algorithm`, `bucket_key_enabled`, `s3_replication_enabled`, and `website_configuration` mutual exclusivity.

## why

*   To resolve a hard Terraform validation failure caused by incorrect `join()` usage with multiple arguments.
*   To prevent runtime errors when replication is enabled but rules are not fully defined, by guarding against null iterations.
*   To ensure SSE configuration is valid according to AWS rules, preventing apply-time errors by only setting KMS-specific fields when `sse_algorithm` is `aws:kms`.
*   To improve module robustness and user experience by providing immediate feedback on invalid configurations and preventing AWS-invalid deployments.

## references

---
<a href="https://cursor.com/background-agent?bcId=bc-afbf7820-1b3d-47c1-aa94-fbf20a0c2b2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-afbf7820-1b3d-47c1-aa94-fbf20a0c2b2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

