### PR TITLE
fix: `aws_bucket_policy.default`

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,2 +1,2 @@
 version: 1
-module_version: 0.0.5
+module_version: 0.0.6

--- a/main.tf
+++ b/main.tf
@@ -468,6 +468,28 @@ data "aws_iam_policy_document" "bucket_policy" {
   }
 }
 
+locals {
+  cross_account_policy_refs = {
+    for ref in var.cross_account_bucket_policy_stacks : ref => {
+      tenant      = split("/", ref)[0]
+      environment = split("/", ref)[1]
+      stage       = split("/", ref)[2]
+      component   = split("/", ref)[3]
+    }
+  }
+
+  cross_account_bucket_policies = local.enabled && length(var.cross_account_bucket_policy_stacks) > 0 ? flatten([
+    for ref, mod in module.cross_account_policy_stacks :
+    try([mod.outputs.cross_account_bucket_policies[data.aws_caller_identity.cross_account[0].account_id][local.bucket_name]], [])
+  ]) : []
+
+  source_policy_documents = compact(concat(
+    [var.policy],
+    var.source_policy_documents,
+    local.cross_account_bucket_policies
+  ))
+}
+
 data "aws_iam_policy_document" "aggregated_policy" {
   count = local.enabled ? 1 : 0
 

--- a/main.tf
+++ b/main.tf
@@ -476,7 +476,7 @@ data "aws_iam_policy_document" "aggregated_policy" {
 }
 
 resource "aws_s3_bucket_policy" "default" {
-  count      = local.enabled && (var.allow_ssl_requests_only || var.allow_encrypted_uploads_only || length(var.s3_replication_source_roles) > 0 || length(var.privileged_principal_arns) > 0 || length(var.source_policy_documents) > 0 || length(var.cross_account_bucket_policy_stacks) > 0) ? 1 : 0
+  count      = local.enabled && (var.allow_ssl_requests_only || var.allow_encrypted_uploads_only || length(var.s3_replication_source_roles) > 0 || length(var.privileged_principal_arns) > 0 || length(var.source_policy_documents) > 0 || length(local.cross_account_bucket_policies) > 0) ? 1 : 0
   bucket     = join("", aws_s3_bucket.default.*.id)
   policy     = join("", data.aws_iam_policy_document.aggregated_policy.*.json)
   depends_on = [aws_s3_bucket_public_access_block.default]

--- a/variables.tf
+++ b/variables.tf
@@ -46,28 +46,6 @@ variable "cross_account_bucket_policy_stacks" {
     EOT
 }
 
-locals {
-  cross_account_policy_refs = {
-    for ref in var.cross_account_bucket_policy_stacks : ref => {
-      tenant      = split("/", ref)[0]
-      environment = split("/", ref)[1]
-      stage       = split("/", ref)[2]
-      component   = split("/", ref)[3]
-    }
-  }
-
-  cross_account_bucket_policies = local.enabled && length(var.cross_account_bucket_policy_stacks) > 0 ? flatten([
-    for ref, mod in module.cross_account_policy_stacks :
-    try([mod.outputs.cross_account_bucket_policies[data.aws_caller_identity.cross_account[0].account_id][local.bucket_name]], [])
-  ]) : []
-
-  source_policy_documents = compact(concat(
-    [var.policy],
-    var.source_policy_documents,
-    local.cross_account_bucket_policies
-  ))
-}
-
 variable "force_destroy" {
   type        = bool
   default     = false


### PR DESCRIPTION
## what

- use `local.cross_account_bucket_policies` instead of `var.cross_account_bucket_policy_stacks` when building `aws_s3_bucket_policy.default`

## why

- var.cross_account_bucket_policy_stacks is set on all stacks configs that import an s3-bucket in the infrastructure repo due to the [mixin](https://github.com/BrightDotAi/infrastructure/blob/6d1d8bbba341516804dc061aba3323708815a7e3/stacks/catalog/s3/cross-account-policies.yaml#L11)
- this means it is always > 0 and a policy is created despite cases when there are no dynamic `statements`
```terraform
# module.kinesis-errors-s3.aws_s3_bucket_policy.default[0] will be created
  + resource "aws_s3_bucket_policy" "default" {
      + bucket = "bai-stl452skylark-uw2-dev-kodiak-data-kinesis-errors"
      + id     = (known after apply)
      + policy = jsonencode(
            {
              + Version = "2012-10-17"
            }
        )
      + region = "us-west-2"
    }
```
- results in terraform apply error

## references

- https://brightdotai.app.spacelift.io/stack/stl452skylark-uw2-dev-kodiak-data/run/01KPPCMYKQQTHZ57G5VE8RH3P1
```terraform
 Error: putting S3 Bucket (bai-stl452skylark-uw2-dev-kodiak-data-kinesis-errors) Policy: operation error S3: PutBucketPolicy, https response error StatusCode: 400, RequestID: VQVZBM2NW213BQRT, HostID: mzWPaU0d58zQeCpoRVrxcxDkb/KbiY7YYrIFZXayq0P5CC2Ax4QGtrLZybdK+8eU02/bFj08HnM=, api error MalformedPolicy: Missing required field Statement
│ 
│   with module.kinesis-errors-s3.aws_s3_bucket_policy.default[0],
│   on .terraform/modules/kinesis-errors-s3/main.tf line 478, in resource "aws_s3_bucket_policy" "default":
│  478: resource "aws_s3_bucket_policy" "default" {
│ 
```